### PR TITLE
Fixed typo

### DIFF
--- a/doxygen/main.inc
+++ b/doxygen/main.inc
@@ -29,7 +29,7 @@
  * - Fully documented
  * - Robust
  *
- * | Libarary       |
+ * | Library        |
  * | :------------- |
  * | @ref config    |
  * | @ref conn      |


### PR DESCRIPTION
The typo also propagated to the generated code docs. In addition, there are several broken links in `README.md`.